### PR TITLE
Ensure that CONNECT grants are applied to all databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ By default, this does setup of the following build standards:
 * If a postgres server has a recovery.conf file it is assumed the server is a slave and puppet does not try to manage users or databases
 
 
-###Setup Requirements **OPTIONAL**
+###Setup Requirements
 
 This module uses the [puppetlabs/puppet-postgresql](https://forge.puppetlabs.com/puppetlabs/postgresql)  module to implement the build standard operations.
 It also uses [arioch/keepalived](https://forge.puppetlabs.com/arioch/keepalived) for initial setup master/slave failover awareness.

--- a/manifests/appuser.pp
+++ b/manifests/appuser.pp
@@ -21,8 +21,9 @@ define cmm_pgsql::appuser (
     }
 
     # give permission for user to connect to the database
-    unless defined(Postgresql::Server::Database_grant[$username]) {
-      postgresql::server::database_grant{ $username:
+    $connect_grant = "connect: ${username}@${database}"
+    unless defined(Postgresql::Server::Database_grant[$connect_grant]) {
+      postgresql::server::database_grant{ $connect_grant:
         privilege => 'CONNECT',
         db        => $database,
         role      => $username,


### PR DESCRIPTION
@cjestel noticed that when multiple roles (users) have access to the same database, the CONNECT grants are only applied to the first database that is created.  That's because we don't specify the database and username on CONNECT grants. This should fix that problem.