### PR TITLE
Support the ACL unless clause in appuser.pp

### DIFF
--- a/templates/grants/super.sql.erb
+++ b/templates/grants/super.sql.erb
@@ -1,2 +1,3 @@
 ALTER GROUP postgres ADD USER "<%= @username %>";
 GRANT select, insert, update, delete ON ALL TABLES IN SCHEMA public TO "<%= @username %>";
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT select, insert, update, delete ON TABLES TO "<%= @username %>";


### PR DESCRIPTION
Currently, appuser.pp uses an unless clause that references default ACLs.  The role template currently doesn't add the any ACL and thus runs and reruns any roles that use the super template.