### PR TITLE
Add non-default schema support

### DIFF
--- a/manifests/appuser.pp
+++ b/manifests/appuser.pp
@@ -72,6 +72,7 @@ define cmm_pgsql::appuser (
                      FROM pg_default_acl a
                      JOIN pg_namespace b ON a.defaclnamespace=b.oid
                      WHERE defaclobjtype = 'r'
+                     AND nspname = '${schema}'
                      AND aclcontains(defaclacl, '\"${username}\"=r/postgres')",
         require    => [ Postgresql::Server::Role[$username], Postgresql::Server::Schema[$schema_create] ],
       }

--- a/manifests/appuser.pp
+++ b/manifests/appuser.pp
@@ -65,7 +65,6 @@ define cmm_pgsql::appuser (
       postgresql_psql { $role_grants:
         command    => template("cmm_pgsql/grants/${role}.sql.erb"),
         db         => $database,
-        schema     => $schema,
         psql_user  => $::postgresql::server::user,
         psql_group => $::postgresql::server::group,
         psql_path  => $::postgresql::server::psql_path,
@@ -74,7 +73,7 @@ define cmm_pgsql::appuser (
                      JOIN pg_namespace b ON a.defaclnamespace=b.oid
                      WHERE defaclobjtype = 'r'
                      AND aclcontains(defaclacl, '\"${username}\"=r/postgres')",
-        require    => Postgresql::Server::Role[$username],
+        require    => [ Postgresql::Server::Role[$username], Postgresql::Server::Schema[$schema_create] ],
       }
     }
   }

--- a/manifests/appuser.pp
+++ b/manifests/appuser.pp
@@ -5,7 +5,7 @@ define cmm_pgsql::appuser (
   $host,
   $username,
   $password,
-  $schema = public,
+  $schema         = 'public',
   $default_handle = false,
 ) {
 

--- a/templates/grants/db_owner.sql.erb
+++ b/templates/grants/db_owner.sql.erb
@@ -1,7 +1,7 @@
-GRANT create ON  SCHEMA public TO "<%= @username %>";
-GRANT ALL ON ALL TABLES IN SCHEMA public TO "<%= @username %>";
-GRANT execute ON ALL functions IN SCHEMA public TO "<%= @username %>"; 
-GRANT USAGE ON ALL sequences IN SCHEMA public TO "<%= @username %>";
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO "<%= @username %>";
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT execute ON functions to "<%= @username %>";
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT usage ON sequences to "<%= @username %>";
+GRANT create ON  SCHEMA "<%= @schema %>" TO "<%= @username %>";
+GRANT ALL ON ALL TABLES IN SCHEMA "<%= @schema %>" TO "<%= @username %>";
+GRANT execute ON ALL functions IN SCHEMA "<%= @schema %>" TO "<%= @username %>"; 
+GRANT USAGE ON ALL sequences IN SCHEMA "<%= @schema %>" TO "<%= @username %>";
+ALTER DEFAULT PRIVILEGES IN SCHEMA "<%= @schema %>" GRANT ALL ON TABLES TO "<%= @username %>";
+ALTER DEFAULT PRIVILEGES IN SCHEMA "<%= @schema %>" GRANT execute ON functions to "<%= @username %>";
+ALTER DEFAULT PRIVILEGES IN SCHEMA "<%= @schema %>" GRANT usage ON sequences to "<%= @username %>";

--- a/templates/grants/default_readonly.sql.erb
+++ b/templates/grants/default_readonly.sql.erb
@@ -1,7 +1,7 @@
-grant usage on schema public to "<%= @username %>";
-grant select on all tables in schema public to "<%= @username %>";
-alter default privileges in schema public grant select on tables to "<%= @username %>";
-grant usage on all sequences in schema public to "<%= @username %>";
-alter default privileges in schema public grant usage on sequences to "<%= @username %>";
-grant execute on all functions in schema public to "<%= @username %>";
-alter default privileges in schema public grant execute on functions to "<%= @username %>";
+grant usage on schema "<%= @schema %>" to "<%= @username %>";
+grant select on all tables in schema "<%= @schema %>" to "<%= @username %>";
+alter default privileges in schema "<%= @schema %>" grant select on tables to "<%= @username %>";
+grant usage on all sequences in schema "<%= @schema %>" to "<%= @username %>";
+alter default privileges in schema "<%= @schema %>" grant usage on sequences to "<%= @username %>";
+grant execute on all functions in schema "<%= @schema %>" to "<%= @username %>";
+alter default privileges in schema "<%= @schema %>" grant execute on functions to "<%= @username %>";

--- a/templates/grants/default_write.sql.erb
+++ b/templates/grants/default_write.sql.erb
@@ -1,6 +1,6 @@
-GRANT select, insert, update, delete ON ALL TABLES IN SCHEMA public TO "<%= @username %>";
-GRANT execute ON ALL functions IN SCHEMA public TO "<%= @username %>"; 
-GRANT USAGE ON ALL sequences IN SCHEMA public TO "<%= @username %>";
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT select, insert, update, delete ON TABLES TO "<%= @username %>";
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT execute ON functions to "<%= @username %>";
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT usage ON sequences to "<%= @username %>";
+GRANT select, insert, update, delete ON ALL TABLES IN SCHEMA "<%= @schema %>" TO "<%= @username %>";
+GRANT execute ON ALL functions IN SCHEMA "<%= @schema %>" TO "<%= @username %>"; 
+GRANT USAGE ON ALL sequences IN SCHEMA "<%= @schema %>" TO "<%= @username %>";
+ALTER DEFAULT PRIVILEGES IN SCHEMA "<%= @schema %>" GRANT select, insert, update, delete ON TABLES TO "<%= @username %>";
+ALTER DEFAULT PRIVILEGES IN SCHEMA "<%= @schema %>" GRANT execute ON functions to "<%= @username %>";
+ALTER DEFAULT PRIVILEGES IN SCHEMA "<%= @schema %>" GRANT usage ON sequences to "<%= @username %>";

--- a/templates/grants/super.sql.erb
+++ b/templates/grants/super.sql.erb
@@ -1,5 +1,5 @@
 ALTER GROUP postgres ADD USER "<%= @username %>";
-GRANT select, insert, update, delete ON ALL TABLES IN SCHEMA public TO "<%= @username %>";
-GRANT usage, select ON ALL SEQUENCES IN SCHEMA public TO "<%= @username %>";
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT select, insert, update, delete ON TABLES TO "<%= @username %>";
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT usage, select ON SEQUENCES TO "<%= @username %>";
+GRANT select, insert, update, delete ON ALL TABLES IN SCHEMA "<%= @schema %>" TO "<%= @username %>";
+GRANT usage, select ON ALL SEQUENCES IN SCHEMA "<%= @schema %>" TO "<%= @username %>";
+ALTER DEFAULT PRIVILEGES IN SCHEMA "<%= @schema %>" GRANT select, insert, update, delete ON TABLES TO "<%= @username %>";
+ALTER DEFAULT PRIVILEGES IN SCHEMA "<%= @schema %>" GRANT usage, select ON SEQUENCES TO "<%= @username %>";


### PR DESCRIPTION
This change will support having user permissions in schema's other than public. Puppet will create the schema based on the hash passed in for the users permissions.