### PR TITLE
added schema to role designation for permission check

### DIFF
--- a/manifests/appuser.pp
+++ b/manifests/appuser.pp
@@ -60,7 +60,7 @@ define cmm_pgsql::appuser (
       }
     }
 
-    $role_grants = "role:${role} ${username}@${database}"
+    $role_grants = "role:${role} ${schema} ${username}@${database}"
     unless defined(Postgresql_psql[$role_grants]) {
       postgresql_psql { $role_grants:
         command    => template("cmm_pgsql/grants/${role}.sql.erb"),


### PR DESCRIPTION
The permission wasn't being applied to all schema's, just the first one that was run across for a user. This ensures all schemas get the correct permission.