### PR TITLE
Add an option to pass a notes_url parameter to the monitor definition.

### DIFF
--- a/manifests/monitoring_wrapper.pp
+++ b/manifests/monitoring_wrapper.pp
@@ -10,10 +10,12 @@ define cmm_pgsql::monitoring_wrapper (
   $monitor_description  = $title,
   $monitor_command      = 'check_postgresql',
   $monitor_args         = undef,
+  $notes_url            = undef,
 ) {
 
   ::monitoring::target::service {"${monitor_description}-${::hostname}":
-    command => "${monitor_command}! ${monitor_args}",
+    command   => "${monitor_command}! $monitor_args",
+    notes_url => $notes_url,
   }
 
 }


### PR DESCRIPTION
This lets us add a link to documentation on how to troubleshoot.