### PR TITLE
switch to pe_postgresql

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     }
    ],
   "dependencies": [
-    { "name": "puppetlabs/postgresql", "version_requirement": ">=3.3.3 <=4.3.0" },
+    { "name": "puppetlabs/pe_postgresql", "version_requirement": ">=v2015.3.0" },
     { "name": "yo61/logrotate", "version_requirement": ">=1.2.0" }
   ]
 }


### PR DESCRIPTION
This should have no functionality change - just a metadata change. Since we use PE the postgresql module name is different as is the version string