### PR TITLE
add a new fact called pg_role, which is slave

### DIFF
--- a/lib/facter/pg_replication.rb
+++ b/lib/facter/pg_replication.rb
@@ -30,5 +30,13 @@ if File.file?(psql_bin)
         File.file?("#{pg_data}/failover.txt")
       end
     end
+
+    # set pg_role to default to slave.
+    # it will be manually overridden
+    Facter.add('pg_role') do
+      setcode do
+        'slave'
+      end
+    end
   end
 end


### PR DESCRIPTION
This fact defaults to slave, which is the opposite of `pg_ismaster`. We will be using this as a manual failover fact, so `master` will be statically set on systems.