### PR TITLE
added line to follow most recent timeline

### DIFF
--- a/templates/scripts/make_pg_slave.sh.erb
+++ b/templates/scripts/make_pg_slave.sh.erb
@@ -114,7 +114,8 @@ EOF
 
   su - postgres -c "echo -e \"standby_mode = 'on'
 primary_conninfo = 'host=${REPL_HOST} sslmode=${SSLMODE} user=${REPL_USER} password=${REPL_PASS}'
-trigger_file = '${TRIGGER_FILE}' \" > ${PGDATADEST}/recovery.conf"
+trigger_file = '${TRIGGER_FILE}' \" > ${PGDATADEST}/recovery.conf
+recovery_target_timeline = 'latest'"
 
   if ! [ "$BACKUP" = "true" ]  
   then


### PR DESCRIPTION
If you had a cascasded setup of A->B->C, where A was your master, if you were to failover to B, B would change the timeline as part of the promotion process and C will not correctly follow B unless you tell it to follow the latest timeline. Adding this line to recovery.conf will fix this issue. When version 10 of postgres is released, this file is no longer valid and the script will need to change again or support for multiple versions will need to be added.