### PR TITLE
fixed slave creation script as it didnt populate file correctly.

### DIFF
--- a/templates/scripts/make_pg_slave.sh.erb
+++ b/templates/scripts/make_pg_slave.sh.erb
@@ -114,8 +114,8 @@ EOF
 
   su - postgres -c "echo -e \"standby_mode = 'on'
 primary_conninfo = 'host=${REPL_HOST} sslmode=${SSLMODE} user=${REPL_USER} password=${REPL_PASS}'
-trigger_file = '${TRIGGER_FILE}' \" > ${PGDATADEST}/recovery.conf
-recovery_target_timeline = 'latest'"
+trigger_file = '${TRIGGER_FILE}' \"
+recovery_target_timeline = 'latest'\" > ${PGDATADEST}/recovery.conf"
 
   if ! [ "$BACKUP" = "true" ]  
   then

--- a/templates/scripts/make_pg_slave.sh.erb
+++ b/templates/scripts/make_pg_slave.sh.erb
@@ -114,7 +114,7 @@ EOF
 
   su - postgres -c "echo -e \"standby_mode = 'on'
 primary_conninfo = 'host=${REPL_HOST} sslmode=${SSLMODE} user=${REPL_USER} password=${REPL_PASS}'
-trigger_file = '${TRIGGER_FILE}' \"
+trigger_file = '${TRIGGER_FILE}'
 recovery_target_timeline = 'latest'\" > ${PGDATADEST}/recovery.conf"
 
   if ! [ "$BACKUP" = "true" ]  

--- a/templates/scripts/make_pg_slave.sh.erb
+++ b/templates/scripts/make_pg_slave.sh.erb
@@ -101,7 +101,7 @@ setup_replication() {
   MAX_RATE: $MAX_RATE
   "
 
-  su - postgres -c "pg_basebackup -r $MAX_RATE -D ${PGDATADEST} ${BACKUPARGS} --host=${REPL_HOST} --port=${PGPORT} -x -P --username=${REPL_USER} --password" <<EOF
+  su - postgres -c "pg_basebackup -r $MAX_RATE -D ${PGDATADEST} ${BACKUPARGS} --host=${REPL_HOST} --port=${PGPORT} --xlog-method=s -P --username=${REPL_USER} --password" <<EOF
 ${REPL_PASS}
 EOF
   RC=$?


### PR DESCRIPTION
https://github.com/covermymeds/cmm_pgsql/pull/35 incorrectly changed the recovery.conf file. This fixes that and also changes the method used from fetch to stream which makes standing up slaves work faster and exposes less room for errors standing slaves up across the wan on high traffic servers.