### PR TITLE
Rename schema resource to work around duplicate public shemas

### DIFF
--- a/manifests/appuser.pp
+++ b/manifests/appuser.pp
@@ -51,7 +51,8 @@ define cmm_pgsql::appuser (
     }
     
     # give permissions to the user on the schema
-    $schema_create = "schema: ${schema} ${username}@${database}"
+    #$schema_create = "schema: ${schema} ${username}@${database}"
+    $schema_create = "${database}: CREATE SCHEMA \"${schema}\""
     unless defined(Postgresql::Server::Schema[$schema_create]) {
       postgresql::server::schema{ $schema_create:
         db     => $database,

--- a/manifests/appuser.pp
+++ b/manifests/appuser.pp
@@ -51,7 +51,6 @@ define cmm_pgsql::appuser (
     }
     
     # give permissions to the user on the schema
-    #$schema_create = "schema: ${schema} ${username}@${database}"
     $schema_create = "${database}: CREATE SCHEMA \"${schema}\""
     unless defined(Postgresql::Server::Schema[$schema_create]) {
       postgresql::server::schema{ $schema_create:


### PR DESCRIPTION
Updating to puppetlabs-postgresql 5.0.0 causes this module to generate a duplicate resource error when the appuser define specifies 'public' for the value of $schema.

This works around the issue by changing the name of the resource so that the existing 'unless defined' check prevents the duplicate.