### PR TITLE
adding logic to remove the 'checkpoint_segments' config option

### DIFF
--- a/manifests/appuser.pp
+++ b/manifests/appuser.pp
@@ -51,7 +51,7 @@ define cmm_pgsql::appuser (
     }
     
     # give permissions to the user on the schema
-    $schema_create = "schema: ${schema} ${username}@${database}"
+    $schema_create = "schema: ${schema} ${database}"
     unless defined(Postgresql::Server::Schema[$schema_create]) {
       postgresql::server::schema{ $schema_create:
         db     => $database,

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -12,17 +12,24 @@ class cmm_pgsql::setup (
       ensure => 'present',
     }
 
-    #filter out 'checkpoint_segments' from 9.5+ hosts
-    if versioncmp('9.5', $::postgresql::globals::version) >= 0 {
-      $cs_rm = {
-        'checkpoint_segments' => {
-          ensure => 'absent'
+    # Create a filter to limit the options based on the postgresql version
+    case versioncmp($::postgresql::globals::version, '9.5') {
+      -1: {
+          # below version 9.5, remove min_wal_size and max_wal_size
+          $filter = {
+            'min_wal_size' => { ensure => 'absent' },
+            'max_wal_size' => { ensure => 'absent' }
+          }
         }
-      }
-      create_resources(::postgresql::server::config_entry, merge($config, $cs_rm), $defaults)
-    } else {
-      create_resources(::postgresql::server::config_entry, $config, $defaults)
+      0,1: {
+          # 9.5 and above, remove checkpoint_segments
+          $filter = {
+            'checkpoint_segments' => { ensure => 'absent' }
+          }
+        }
+      default: { $filter = { } }
     }
+    create_resources(::postgresql::server::config_entry, merge($config, $filter), $defaults)
   }
 
   #setup log management
@@ -57,20 +64,20 @@ class cmm_pgsql::setup (
       group   => $::postgresql::server::group,
       mode    => '0700',
       require => Class['::postgresql::server::initdb'],
-    } ->
-    file { '/var/lib/pgsql/.ssh/id_rsa':
+    }
+    -> file { '/var/lib/pgsql/.ssh/id_rsa':
       mode   => '0600',
       owner  => $::postgresql::server::user,
       group  => $::postgresql::server::group,
       source => "${::cmm_pgsql::keysource}/id_rsa",
-    } ->
-    file { '/var/lib/pgsql/.ssh/id_rsa.pub':
+    }
+    -> file { '/var/lib/pgsql/.ssh/id_rsa.pub':
       mode   => '0600',
       owner  => $::postgresql::server::user,
       group  => $::postgresql::server::group,
       source => "${::cmm_pgsql::keysource}/id_rsa.pub",
-    } ->
-    file { '/var/lib/pgsql/.ssh/authorized_keys':
+    }
+    -> file { '/var/lib/pgsql/.ssh/authorized_keys':
       mode   => '0600',
       owner  => $::postgresql::server::user,
       group  => $::postgresql::server::group,

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -1,3 +1,4 @@
+# Setup postgresql config
 class cmm_pgsql::setup (
   $pg_archive_dir = '/var/lib/pgsql/archive',
 ){
@@ -11,7 +12,17 @@ class cmm_pgsql::setup (
       ensure => 'present',
     }
 
-    create_resources(::postgresql::server::config_entry, $config, $defaults)
+    #filter out 'checkpoint_segments' from 9.5+ hosts
+    if versioncmp('9.5', $::postgresql::globals::version) >= 0 {
+      $cs_rm = {
+        'checkpoint_segments' => {
+          ensure => 'absent'
+        }
+      }
+      create_resources(::postgresql::server::config_entry, merge($config, $cs_rm), $defaults)
+    } else {
+      create_resources(::postgresql::server::config_entry, $config, $defaults)
+    }
   }
 
   #setup log management


### PR DESCRIPTION
In postgresql versions 9.5+, having the config option `checkpoint_segments` enabled causes the service to not be able to start.