### PR TITLE
STPO-2713: ensure JobResults exists after CommVault install

### DIFF
--- a/manifests/commvault_backup.pp
+++ b/manifests/commvault_backup.pp
@@ -13,4 +13,11 @@ class cmm_pgsql::commvault_backup (
   package { 'cmm-cv_iDA-pgsql':
     ensure => installed,
   }
+
+  file { ['/opt/simpana', '/opt/simpana/JobResults']:
+    ensure  => 'directory',
+    owner   => 'root',
+    group   => 'postgres',
+    mode    => '0775',
+    require => Package['cmm-cv_iDA-pgsql'],
 }


### PR DESCRIPTION
This is to ensure /opt/simpana/JobResults folder exists after installing CommVault.
I figured it is more intuitive to do it in this module rather than under puppet/control as this folder is supposed to come with CommVault.